### PR TITLE
Fixed Hoard typo: Horde -> Hoard

### DIFF
--- a/treasure.html
+++ b/treasure.html
@@ -59,16 +59,16 @@
                     <a href="#cr17">Individual: CR 17+</a>
                 </li>
 				<li>
-                    <a href="#horde4">Horde: CR 0-4</a>
+                    <a href="#hoard4">Hoard: CR 0-4</a>
                 </li>
 				<li>
-                    <a href="#horde10">Horde: CR 5-10</a>
+                    <a href="#hoard10">Hoard: CR 5-10</a>
                 </li>
 				<li>
-                    <a href="#horde16">Horde: CR 11-16</a>
+                    <a href="#hoard16">Hoard: CR 11-16</a>
                 </li>	
 				<li>
-                    <a href="#horde17">Horde: CR 17+</a>
+                    <a href="#hoard17">Hoard: CR 17+</a>
                 </li>
 				<li>
                     <a href="#gems">Gems</a>
@@ -327,9 +327,9 @@
 							
 							
 					
-							<a name="horde4"></a> 
+							<a name="hoard4"></a> 
 							<div class="table-title">
-							<h3>Treasure Horde: Challenge 0-4</h3>
+							<h3>Treasure Hoard: Challenge 0-4</h3>
 							</div>
 							<table class="table table-striped table-bordered">
 							<thead>
@@ -448,9 +448,9 @@
 							</table>			
 							</div>	
 
-							<a name="horde10"></a> 
+							<a name="hoard10"></a> 
 							<div class="table-title">
-							<h3>Treasure Horde: Challenge 5-10</h3>
+							<h3>Treasure Hoard: Challenge 5-10</h3>
 							</div>
 							<table class="table table-striped table-bordered">
 							<thead>
@@ -629,9 +629,9 @@
 							</table>
 
 
-							<a name="horde16"></a> 
+							<a name="hoard16"></a> 
 							<div class="table-title">
-							<h3>Treasure Horde: Challenge 11-16</h3>
+							<h3>Treasure Hoard: Challenge 11-16</h3>
 							</div>
 							<table class="table table-striped table-bordered">
 							<thead>
@@ -829,9 +829,9 @@
 							</tbody>	
 							</table>							
 							
-							<a name="horde17"></a> 
+							<a name="hoard17"></a> 
 							<div class="table-title">
-							<h3>Treasure Horde: Challenge 17+</h3>
+							<h3>Treasure Hoard: Challenge 17+</h3>
 							</div>
 							<table class="table table-striped table-bordered">
 							<thead>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4104557/59806342-a963b600-92b9-11e9-82b4-497dcb6c53dd.png)

![image](https://user-images.githubusercontent.com/4104557/59806372-b2548780-92b9-11e9-8662-085d3bb4906f.png)

I feel it'd make more sense to refer to the treasure rather than the group. A single Beholder could have a Treasure Hoard. But a Horde of goblins won't necessarily have a Treasure Hoard.