### PR TITLE
Update treasure.html

### DIFF
--- a/treasure.html
+++ b/treasure.html
@@ -397,52 +397,52 @@
 							<tr>
 								<td>61–65</td>
 								<td colspan="2">2d6 (7) 10 gp gems</td>
-								<td colspan="3">Roll 1d6 times on Magic Item Table B.</td>
+								<td colspan="3">Roll 1d4 times on Magic Item Table B.</td>
 							</tr>
 							<tr>
 								<td>66–70</td>
 								<td colspan="2">2d4 (5) 25 gp art objects</td>
-								<td colspan="3">Roll 1d6 times on Magic Item Table B.</td>
+								<td colspan="3">Roll 1d4 times on Magic Item Table B.</td>
 							</tr>
 							<tr>
 								<td>71–75</td>
 								<td colspan="2">2d6 (7) 50 gp gems</td>
-								<td colspan="3">Roll 1d6 times on Magic Item Table B.</td>
+								<td colspan="3">Roll 1d4 times on Magic Item Table B.</td>
 							</tr>
 							<tr>
 								<td>76–78</td>
 								<td colspan="2">2d6 (7) 10 gp gems</td>
-								<td colspan="3">Roll 1d6 times on Magic Item Table C.</td>
+								<td colspan="3">Roll 1d4 times on Magic Item Table C.</td>
 							</tr>
 							<tr>
 								<td>79–80</td>
 								<td colspan="2">2d4 (5) 25 gp art objects</td>
-								<td colspan="3">Roll 1d6 times on Magic Item Table C.</td>
+								<td colspan="3">Roll 1d4 times on Magic Item Table C.</td>
 							</tr>
 							<tr>
 								<td>81–85</td>
 								<td colspan="2">2d6 (7) 50 gp gems</td>
-								<td colspan="3">Roll 1d6 times on Magic Item Table C.</td>
+								<td colspan="3">Roll 1d4 times on Magic Item Table C.</td>
 							</tr>
 							<tr>
 								<td>86–92</td>
 								<td colspan="2">2d4 (5) 25 gp art objects</td>
-								<td colspan="3">Roll 1d6 times on Magic Item Table F.</td>
+								<td colspan="3">Roll 1d4 times on Magic Item Table F.</td>
 							</tr>
 							<tr>
 								<td>93–97</td>
 								<td colspan="2">2d6 (7) 50 gp gems</td>
-								<td colspan="3">Roll 1d6 times on Magic Item Table F.</td>
+								<td colspan="3">Roll 1d4 times on Magic Item Table F.</td>
 							</tr>
 							<tr>
 								<td>98–99</td>
 								<td colspan="2">2d4 (5) 25 gp art objects</td>
-								<td colspan="3">Roll 1d6 times on Magic Item Table G.</td>
+								<td colspan="3">Roll once on Magic Item Table G.</td>
 							</tr>
 														<tr>
 								<td>100</td>
 								<td colspan="2">2d6 (7) 50 gp gems</td>
-								<td colspan="3">Roll 1d6 times on Magic Item Table G.</td>
+								<td colspan="3">Roll once on Magic Item Table G.</td>
 							</tr>
 							</tbody>	
 							</table>			


### PR DESCRIPTION
The amount of rolls on the magic item tables were all 1d6, corrected to 1d4 for table B,C,D,F and to once for table G.