### PR TITLE
Fix quarterstaff versatile damage dice from 1d10 to 1d8 (PHB)

### DIFF
--- a/items.html
+++ b/items.html
@@ -485,7 +485,7 @@
              <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;Javelin</td><td >5 sp</td><td >1d6 P</td><td >2 lb.</td><td>Thrown Rg(30/120)</td></tr>
              <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;Light &nbsp;&nbsp;&nbsp;&nbsp;hammer</td><td >2 gp</td><td >1d4 B</td><td >2 lb.</td><td>Thrown Rg(20/60)</td></tr>
              <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;Mace</td><td >5 gp</td><td >1d6 B</td><td >4 lb.</td><td>-</td></tr>
-             <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;Quarterstaff</td><td >2 sp</td><td >1d6 B</td><td >4 lb.</td><td>Versatile(1d10)</td></tr>
+             <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;Quarterstaff</td><td >2 sp</td><td >1d6 B</td><td >4 lb.</td><td>Versatile(1d8)</td></tr>
              <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;Sickle</td><td >1 gp</td><td >1d4 S</td><td >2 lb.</td><td></td></tr>
              <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;Spear</td><td >1 gp</td><td >1d6 P</td><td >3 lb.</td><td>Thrown Rg(20/60), Versatile(1d8)</td></tr>
              <tr><td colspan="5"><i>Simple Ranged Weapons</i></td></tr>


### PR DESCRIPTION
**The Quarterstaff damage was wrong when using it two-handed.**

This PR changes the dice from 1d10 to 1d8